### PR TITLE
Migrate to org roam v2

### DIFF
--- a/org/vulpea-agenda.el
+++ b/org/vulpea-agenda.el
@@ -1,10 +1,11 @@
-;;; vulpea-agenda -- Summary
+;;; vulpea-agenda -- Summary -*- lexical-binding: t; -*-
 ;;; Commentary:
 ;;; Dynamic agenda file manager.
 
 ;;; Code:
 
-(eval-when-compile 'org-macs)
+(require 'org-element)
+(require 'seq)
 
 (defun vulpea-project-p ()
   "Return non-nil if current buffer has any todo entry.
@@ -91,7 +92,7 @@ If nil it defaults to `split-string-default-separators', normally
     (let* ((prop-tags (vulpea-buffer-tags-get))
            (tags prop-tags))
       (if (vulpea-project-p)
-          (setq tags (add-to-list 'tags "project"))
+          (setq tags (cl-pushnew "project" tags :test #'equal))
         (setq tags (remove "project" tags)))
       (unless (eq prop-tags tags)
         (apply #'vulpea-buffer-tags-set tags)))))

--- a/org/vulpea-agenda.el
+++ b/org/vulpea-agenda.el
@@ -4,6 +4,8 @@
 
 ;;; Code:
 
+(eval-when-compile 'org-macs)
+
 (defun vulpea-project-p ()
   "Return non-nil if current buffer has any todo entry.
 
@@ -50,6 +52,11 @@ If the property is already set, replace its value."
             (forward-line)
             (beginning-of-line)))
         (insert "#+" name ": " value "\n")))))
+
+(defun vulpea-buffer-title-set (title)
+  "Set TITLE in current buffer.
+If the title is already set, replace its value."
+  (vulpea-buffer-prop-set "title" title))
 
 (defun vulpea-buffer-prop-get (name)
   "Get a buffer property called NAME as a string."


### PR DESCRIPTION
Referencese:
- [Org Roam wiki](https://github.com/org-roam/org-roam/wiki/Hitchhiker's-Rough-Guide-to-Org-roam-V2)
- [d12frosted's blog](https://d12frosted.io/posts/2021-06-11-path-to-org-roam-v2.html)
- Or, [maintainer's gist](https://gist.github.com/jethrokuan/02f41028fb4a6f81787dc420fb99b6e4)

But, those migration scripts didn't work for me, actually, mangled my notes. Hence, I found myself muddling through weird org roam errors without reliable sources.
In the end, have to fix up files manually, since I haven't backed up my notes before diving into relying on the power of iCloud, which only supports file specific manual revert, not programmatic. 

Had better stash current working state before initiating anything possibly destructive, since with which, I can learn by configuring migrating script, which might contribute to the community.

As this brought disastrous change to note system itself, cannot track how I'm doing now, and what's the next reasonable step to take. Totally numbed myself, just blunted without my fall back option to take step back and overview its outlook.